### PR TITLE
Fix login cookie handling and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@
 
 ## ✨ Features (Current Version)
 
-- 🗳️ Weekly voting system: 10 votes per user, reset every Monday  
-- ✍️ Anonymous or public idea submission  
-- 🌐 Predictive country selection (accent-insensitive)  
-- 📱 Fully responsive design (mobile + desktop)  
-- 🌎 English UI (multilingual support with Lingo coming soon)  
+- 🗳️ Weekly voting system: 10 votes per user, reset every Monday
+- ✍️ Anonymous or public idea submission
+- 🌐 Predictive country selection (accent-insensitive)
+- 📱 Fully responsive design (mobile + desktop)
+- 🌎 English UI (multilingual support with Lingo coming soon)
+- 🍪 Simple session cookie to keep you logged in
 
 ---
 
@@ -64,6 +65,12 @@ Most civic platforms are constrained by geography, bureaucracy, or politics. Ver
 - 💬 Community-driven  
 
 Whether it’s fixing a broken streetlight or proposing a global climate resolution — every voice matters.
+
+---
+
+## 🍪 Cookies
+
+Veroma uses a lightweight cookie called `veroma_session` to keep you logged in after you authenticate. This cookie contains no personal data and expires when you sign out.
 
 ---
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -340,12 +340,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       }
 
       console.log('Signin successful:', authData);
-      
-      // Success handling is done in the auth state change listener
-      // But we'll add a fallback navigation here
-      if (authData.user?.email_confirmed_at) {
-        navigate('/dashboard');
+
+      // Set a simple session cookie to indicate login status
+      if (authData.session) {
+        document.cookie = 'veroma_session=active; path=/; SameSite=Lax';
       }
+
+      // Navigation is handled in the auth state change listener
     } catch (error: any) {
       console.error('Signin error:', error);
       throw error;
@@ -476,6 +477,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       // Clear any cached data
       localStorage.removeItem('veroma-auth-token');
       localStorage.removeItem('supabase.auth.token');
+
+      // Remove login cookie
+      document.cookie = 'veroma_session=; Max-Age=0; path=/; SameSite=Lax';
       
       toast.success('Signed out successfully');
       

--- a/src/pages/CookiesPage.tsx
+++ b/src/pages/CookiesPage.tsx
@@ -58,7 +58,7 @@ export default function CookiesPage() {
                 <h2 className="text-2xl font-semibold text-gray-900 mb-4">3. How We Use Cookies</h2>
                 <p className="text-gray-600 mb-4">We use cookies to:</p>
                 <ul className="list-disc pl-6 text-gray-600 mb-6">
-                  <li className="mb-2">Remember your login status</li>
+                  <li className="mb-2">Remember your login status using the `veroma_session` cookie</li>
                   <li className="mb-2">Maintain your preferences</li>
                   <li className="mb-2">Understand how you use our platform</li>
                   <li className="mb-2">Improve our services</li>

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -20,15 +20,8 @@ export default function LoginPage() {
     try {
       console.log('Attempting to sign in with email:', email);
       await signIn({ email, password });
-      
-      // Navigate to dashboard on successful login
-      // Note: The actual navigation happens in the auth state change listener
-      // This is just a fallback
-      setTimeout(() => {
-        if (!error) {
-          navigate('/dashboard');
-        }
-      }, 1000);
+
+      // Navigation is handled in the auth state change listener
       
     } catch (err) {
       console.error('Login error:', err);


### PR DESCRIPTION
## Summary
- clean up login navigation logic
- set and clear a `veroma_session` cookie during sign in/out
- document the cookie in README
- mention the cookie on the cookies page

## Testing
- `npm run lint` *(fails: 79 errors, 6 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68554536f2508331a8ff6e28b7ec3ed6