### PR TITLE
Fix Supabase env var handling

### DIFF
--- a/src/utils/supabaseClient.ts
+++ b/src/utils/supabaseClient.ts
@@ -23,9 +23,14 @@ const supabaseUrl = getEnvVar('VITE_SUPABASE_URL');
 const supabaseAnonKey = getEnvVar('VITE_SUPABASE_ANON_KEY');
 
 if (!supabaseUrl || !supabaseAnonKey) {
-  throw new Error(`Missing Supabase environment variables: 
-    URL: ${supabaseUrl ? 'defined' : 'missing'}, 
-    Key: ${supabaseAnonKey ? 'defined' : 'missing'}`);
+  // Log a warning instead of throwing to avoid breaking the UI when
+  // environment variables are not provided. Supabase functionality
+  // will simply be disabled in this case.
+  console.warn(
+    `Missing Supabase environment variables:\n` +
+    `  URL: ${supabaseUrl ? 'defined' : 'missing'}\n` +
+    `  Key: ${supabaseAnonKey ? 'defined' : 'missing'}`
+  );
 }
 
 // Get the current domain, handling development and production environments


### PR DESCRIPTION
## Summary
- handle missing Supabase env vars by logging a warning instead of throwing

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6855782313488331bbde4dce4be20c22